### PR TITLE
Add support for v6 fluxnode txes in bitcore-lib and fluxd 

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -2230,10 +2230,18 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
                   hash: txid,
                   size: size,
               };
-              if (tx.version == 5) {
+              if (tx.version == 5 || tx.version == 6) {
                 var FLUXNODE_START_TX_TYPE = 2;
                 var FLUXNODE_CONFIRM_TX_TYPE = 4;
+                var FLUXNODE_NORMAL_TX_VERSION = 1;
+                var FLUXNODE_P2SH_TX_VERSION = 2;
+
+                if (tx.version == 6) {
+                  tx.nFluxNodeTxVersion = result.fluxnode_upgraded_tx_version;
+                }
+
                 tx.type = result.type;
+                
                 var nType = result.hex.slice(8, 10);
                 tx.nType = parseInt(nType, 16);
                 tx.collateralOutput = result.collateral_output;
@@ -2245,7 +2253,17 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
                 tx.sigTime = result.sigtime;
                 tx.sig = result.sig;
                 if (tx.nType == FLUXNODE_START_TX_TYPE) {
-                  tx.collateralPubKey = result.collateral_pubkey;
+                  if (tx.version == 6) {
+                    if (tx.nFluxNodeTxVersion == FLUXNODE_P2SH_TX_VERSION) {
+                      tx.RedeemScript = result.redeemscript;
+                    } else if (tx.nFluxNodeTxVersion == FLUXNODE_NORMAL_TX_VERSION) {
+                      tx.collateralPubKey = result.collateral_pubkey;
+                    }
+                  } else {
+                    // If not version 6, collateralPubKey always in the tx
+                    tx.collateralPubKey = result.collateral_pubkey;
+                  }
+
                   tx.zelnodePubKey = result.zelnode_pubkey;
                   tx.fluxnodePubKey = result.zelnode_pubkey;
                 }

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -2246,8 +2246,14 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
                 tx.nType = parseInt(nType, 16);
                 tx.collateralOutput = result.collateral_output;
                 var collateralOutputHash = result.hex.slice(10, 74);
+                if (tx.version == 6) {
+                  collateralOutputHash = result.hex.slice(18, 82);
+                }
                 tx.collateralOutputHash = collateralOutputHash.match(/[a-fA-F0-9]{2}/g).reverse().join('');
                 var collateralOutputIndexHex = result.hex.slice(74, 82);
+                if (tx.version == 6) {
+                  collateralOutputIndexHex = result.hex.slice(82, 90);
+                }
                 var collateralOutputIndexHexReversedOK = collateralOutputIndexHex.match(/[a-fA-F0-9]{2}/g).reverse().join('');
                 tx.collateralOutputIndex = parseInt(collateralOutputIndexHexReversedOK, 16);
                 tx.sigTime = result.sigtime;
@@ -2255,7 +2261,7 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
                 if (tx.nType == FLUXNODE_START_TX_TYPE) {
                   if (tx.version == 6) {
                     if (tx.nFluxNodeTxVersion == FLUXNODE_P2SH_TX_VERSION) {
-                      tx.RedeemScript = result.redeemscript;
+                      tx.redeemScript = result.redeemscript;
                     } else if (tx.nFluxNodeTxVersion == FLUXNODE_NORMAL_TX_VERSION) {
                       tx.collateralPubKey = result.collateral_pubkey;
                     }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "bitcoind-rpc": "https://github.com/runonflux/bitcoind-rpc#master",
-    "bitcore-lib": "https://github.com/runonflux/bitcore-lib#master",
+    "bitcore-lib": "https://github.com/runonflux/bitcore-lib#v6-transactions",
     "body-parser": "^1.18.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "bitcoind-rpc": "https://github.com/runonflux/bitcoind-rpc#master",
-    "bitcore-lib": "https://github.com/runonflux/bitcore-lib#v6-transactions",
+    "bitcore-lib": "https://github.com/runonflux/bitcore-lib#master",
     "body-parser": "^1.18.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",


### PR DESCRIPTION
- modified bitcoind.js to work with the new fluxd getrawtransaction rpc call to support v6 fluxnode transactions
- modified the package.json to support bitcore-lib branch that also support v6 fluxnode transactions 